### PR TITLE
ci: install full runtime deps in the test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: pip install numpy scipy pytest
+        # Full runtime deps: the panel/dialog/tree tests import wx, and the
+        # DSP/audio tests pull numpy/scipy/sounddevice.  pyrtlsdr imports are
+        # guarded, so the missing librtlsdr DLL doesn't break collection.
+        run: pip install -e . pytest
 
       - name: Run tests
         run: pytest -v


### PR DESCRIPTION
The CI **test** job only installed `numpy scipy pytest`, but several tests (`test_band_tree.py`, `test_mode_settings_dialog.py`, `test_panels.py`) `import wx` at module level. Once the channels/scenes tests landed on master, collection failed with `ModuleNotFoundError: No module named 'wx'`, breaking the Build & Release run on master.

Fix: install the package (`pip install -e .`) in the test job so all runtime deps (wxPython, numpy, scipy, sounddevice, accessible_output2) resolve. pyrtlsdr's import is guarded in `core/sdr_backends.py`, so the absent librtlsdr DLL doesn't break collection.

112 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)