### PR TITLE
feat: hardware-style auto squelch with sensitivity control

### DIFF
--- a/config/channels.py
+++ b/config/channels.py
@@ -34,7 +34,7 @@ class Channel:
     wfm_stereo_mode: Optional[str] = None
     wfm_hiblend_enabled: Optional[bool] = None
     wfm_rds_enabled: Optional[bool] = None
-    squelch: Optional[float] = None     # per-channel squelch (dBm); None = keep
+    squelch_sensitivity: Optional[int] = None  # per-channel sensitivity (0–10); None = keep
 
 
 @dataclass
@@ -82,11 +82,21 @@ def _pmr446_map() -> ChannelMap:
     )
 
 
-def _cb_cept_map() -> ChannelMap:
+def _cb_cept_fm_map() -> ChannelMap:
     return ChannelMap(
         "CB (CEPT FM)",
         [
-            Channel(n, f"CB {n}", hz, "NFM", 12_500)
+            Channel(n, f"CB {n}", hz, "NFM", 12_500, nfm_deviation=2_000)
+            for n, hz in enumerate(_CB_CEPT_HZ, start=1)
+        ],
+    )
+
+
+def _cb_cept_am_map() -> ChannelMap:
+    return ChannelMap(
+        "CB (CEPT AM)",
+        [
+            Channel(n, f"CB {n}", hz, "AM", 6_000)
             for n, hz in enumerate(_CB_CEPT_HZ, start=1)
         ],
     )
@@ -97,7 +107,8 @@ def default_maps() -> List[ChannelMap]:
     return [
         ChannelMap("My Channels", []),
         _pmr446_map(),
-        _cb_cept_map(),
+        _cb_cept_fm_map(),
+        _cb_cept_am_map(),
     ]
 
 

--- a/config/scenes.py
+++ b/config/scenes.py
@@ -41,7 +41,7 @@ class Scene:
     wfm_stereo_mode: Optional[str] = None
     wfm_hiblend_enabled: Optional[bool] = None
     wfm_rds_enabled: Optional[bool] = None
-    squelch: Optional[float] = None
+    squelch_sensitivity: Optional[int] = None  # 0–10; None = keep global
     # Service category, used to group bands in the Bands tree.
     group: str = ""
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,7 +35,8 @@ class Settings:
 
     # Audio
     volume: float = 0.75             # 0.0 – 1.0
-    squelch: float = -80.0           # dBm
+    squelch_sensitivity: int = 5     # 0 = most sensitive, 10 = tightest
+    squelch_enabled: bool = True     # False = squelch off (hear everything)
     squelch_hysteresis_db: float = 3.0   # close threshold is this much below open
     squelch_hang_ms: float = 500.0       # hold-open tail after a signal drops
     muted: bool = False

--- a/core/audio.py
+++ b/core/audio.py
@@ -315,17 +315,21 @@ class AudioOutput:
         self.device = device
         self.blocksize = blocksize
         self.volume: float = 0.75       # 0.0 – 1.0
-        self.squelch: float = -80.0     # dBm; signals below this → silence
+        self.squelch_enabled: bool = True     # False = squelch off (hear everything)
         self.squelch_hysteresis_db: float = 3.0   # close threshold is this much lower
         self.squelch_hang_ms: float = 500.0       # hold-open tail after signal drops
         self.muted: bool = False
         self.signal_db: float = -120.0  # last measured signal strength
 
+        # Auto squelch state (always active when squelch is enabled)
+        self.noise_db: float = 0.0            # signal metric from DSP (mode-dependent)
+        self.auto_squelch_threshold: float = -80.0  # adaptive threshold from DSP
+        self.current_mode: str = "WFM"        # current demodulation mode
+
         # Squelch gate state (smooth open/close with hang time)
         self._sq_open: bool = False
         self._sq_gain: float = 0.0       # current gate gain (0 = muted, 1 = open)
         self._sq_hang_remaining: int = 0  # samples left on the hang timer
-        self._sq_last_squelch: float = self.squelch  # detect manual threshold change
 
         # Ducking: smoothly reduce radio volume while probe tone plays
         self._duck_target: float = 1.0   # 1.0 = full, 0.0 = silent
@@ -340,8 +344,13 @@ class AudioOutput:
         self.audio_overruns: int = 0     # write() dropped (queue full)
 
     def _squelch_hang_samples(self) -> int:
-        """Hang-time tail length in samples (clamped to >= 0)."""
-        return max(0, int(self.sample_rate * self.squelch_hang_ms / 1000.0))
+        """Hang-time tail length in samples (clamped to >= 0).
+
+        Uses half the configured hang time — the adaptive metrics already
+        smooth transients, so a long hold-open tail just adds lag.
+        """
+        ms = self.squelch_hang_ms * 0.5
+        return max(0, int(self.sample_rate * ms / 1000.0))
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -493,33 +502,38 @@ class AudioOutput:
         if take < frames:
             self.audio_underruns += 1
 
-        # Squelch — like a real radio: open instantly, hold briefly through
-        # fades (hang time) with hysteresis, then fade out smoothly.  A hard
-        # gate (mute the instant signal_db dips below threshold) chops speech
-        # between syllables and clicks; this avoids both.
-        # A manual threshold change (the user moving the squelch control) must
-        # take effect immediately — re-evaluate against the new value directly,
-        # without carrying over the previous hang timer or hysteresis dead-zone.
-        if self.squelch != self._sq_last_squelch:
-            self._sq_last_squelch = self.squelch
-            self._sq_open = self.signal_db >= self.squelch
-            self._sq_hang_remaining = (
-                self._squelch_hang_samples() if self._sq_open else 0
-            )
-
-        open_thr = self.squelch
-        close_thr = self.squelch - self.squelch_hysteresis_db
-        if self.signal_db >= open_thr:
+        # Squelch — hardware-style carrier squelch with hysteresis,
+        # hang time, and smooth ramping.  Three strategies by mode:
+        #   FM (WFM/NFM): above-audio noise power (lower = stronger signal)
+        #   AM/DSB: carrier-to-noise ratio (higher = stronger signal)
+        #   SSB/CW: adaptive RSSI floor (higher = stronger signal)
+        # When squelch is disabled, the gate is always open.
+        if not self.squelch_enabled:
             self._sq_open = True
-            self._sq_hang_remaining = self._squelch_hang_samples()
-        elif self._sq_open and self.signal_db < close_thr:
-            self._sq_hang_remaining -= frames
-            if self._sq_hang_remaining <= 0:
-                self._sq_open = False
+        else:
+            if self.current_mode in ("WFM", "NFM"):
+                # FM carrier squelch: low noise = signal present (open).
+                signal_present = self.noise_db < self.auto_squelch_threshold
+                signal_absent = self.noise_db > (
+                    self.auto_squelch_threshold + self.squelch_hysteresis_db
+                )
+            else:
+                # AM/DSB/SSB/CW: higher metric = stronger signal.
+                signal_present = self.noise_db >= self.auto_squelch_threshold
+                signal_absent = self.noise_db < (
+                    self.auto_squelch_threshold - self.squelch_hysteresis_db
+                )
+            if signal_present:
+                self._sq_open = True
+                self._sq_hang_remaining = self._squelch_hang_samples()
+            elif self._sq_open and signal_absent:
+                self._sq_hang_remaining -= frames
+                if self._sq_hang_remaining <= 0:
+                    self._sq_open = False
         sq_target = 1.0 if self._sq_open else 0.0
         if abs(self._sq_gain - sq_target) > 1e-4:
-            # Fast attack (~5 ms) when opening, slower release (~40 ms) closing.
-            tc = 0.005 if sq_target > self._sq_gain else 0.040
+            # Fast attack (~5 ms) when opening, snappy release (~20 ms).
+            tc = 0.005 if sq_target > self._sq_gain else 0.020
             alpha = 1.0 - math.exp(-1.0 / (self.sample_rate * tc))
             k = 1.0 - alpha
             idx = np.arange(1, frames + 1, dtype=np.float64)

--- a/core/dsp/demodulator.py
+++ b/core/dsp/demodulator.py
@@ -31,6 +31,7 @@ from config.locale_utils import detect_deemphasis_tau
 from .ctcss import CTCSSDetector
 from .filters import Resampler, make_lowpass_iir, make_bandpass_iir, deemphasis_filter
 from .rds import RDSDecoder
+from .squelch_metric import AMCarrierMetric, FMNoiseMetric
 
 logger = logging.getLogger(__name__)
 
@@ -193,12 +194,20 @@ class WFMDemodulator(Demodulator):
         # RDS decoder
         self._rds = RDSDecoder(baseband_rate)
 
+        # Carrier squelch: above-audio noise metric
+        self._noise_metric = FMNoiseMetric(baseband_rate, "WFM")
+
         self.stereo_detected: bool = False
         self._pilot_count: int = 0
         self._pilot_check_ctr: int = 0
         self._stereo_blend: float = 0.0   # 0 = mono, 1 = full stereo
         self._last_pilot_snr: float = 0.0
         self._hiblend: float = 0.0        # 0 = full BW, 1 = hi-cut active
+
+    @property
+    def noise_db(self) -> float:
+        """Above-audio noise power (dB) — lower = stronger FM signal."""
+        return self._noise_metric._smooth_db
 
     @property
     def rds_station(self) -> str:
@@ -228,6 +237,9 @@ class WFMDemodulator(Demodulator):
 
         # FM discriminant → normalized MPX baseband (±1.0 at full deviation)
         mpx = _fm_discriminant(iq) * self._disc_gain
+
+        # Carrier squelch: measure above-audio noise in discriminator output
+        self._noise_metric.process(mpx)
 
         # Extract L+R (mono sum, 0–15 kHz)
         lpr, self._zi_lpr = sp_signal.sosfilt(
@@ -418,12 +430,27 @@ class NFMDemodulator(Demodulator):
         self._zi_lp = sp_signal.sosfilt_zi(self._lp_sos) * 0.0
         # CTCSS tone detector (operates on resampled audio)
         self._ctcss = CTCSSDetector(audio_rate)
+        # Carrier squelch: above-audio noise metric.
+        # The noise band sits just above the expected audio content.
+        # For narrow-deviation signals (e.g. CB ±2 kHz), audio tops out
+        # around deviation + 0.5 kHz, so the noise band must be lower
+        # than the standard 4–6 kHz to actually sit above the signal.
+        audio_top = deviation + 500.0  # Hz
+        noise_lo = max(audio_top, 3_000.0)  # never below 3 kHz
+        noise_hi = noise_lo + 2_000.0       # 2 kHz wide band
+        self._noise_metric = FMNoiseMetric(
+            baseband_rate, "NFM", noise_band=(noise_lo, noise_hi))
         # CTCSS notch filter state
         self._ctcss_notch_enabled: bool = kwargs.get("ctcss_notch", True)
         self._notch_tone: float | None = None
         self._notch_b: np.ndarray | None = None
         self._notch_a: np.ndarray | None = None
         self._notch_zi: np.ndarray | None = None
+
+    @property
+    def noise_db(self) -> float:
+        """Above-audio noise power (dB) — lower = stronger FM signal."""
+        return self._noise_metric._smooth_db
 
     @property
     def ctcss_tone(self) -> float | None:
@@ -437,6 +464,8 @@ class NFMDemodulator(Demodulator):
         if float(np.sqrt(np.mean(np.square(mag)))) > 0.03:
             iq = iq / np.maximum(mag, np.float32(1e-10))
         disc = _fm_discriminant(iq) * self._disc_gain
+        # Carrier squelch: measure above-audio noise in discriminator output
+        self._noise_metric.process(disc)
         audio, self._zi_lp = sp_signal.sosfilt(
             self._lp_sos, disc, zi=self._zi_lp)
         resampled = self._resample(audio)
@@ -483,10 +512,20 @@ class AMDemodulator(Demodulator):
         self._zi_dc = sp_signal.lfilter_zi(self._dc_b, self._dc_a) * 0.0
         # Smoothed carrier amplitude for AM AGC (0 = not yet seeded).
         self._carrier_level: float = 0.0
+        # Carrier-to-noise squelch metric
+        self._cnr_metric = AMCarrierMetric()
+
+    @property
+    def cnr_db(self) -> float:
+        """Carrier-to-noise ratio (dB) — higher = stronger AM signal."""
+        return self._cnr_metric._smooth_db
 
     def process(self, iq: np.ndarray) -> np.ndarray:
         iq = self._channel_filter(iq)
         envelope = np.abs(iq).astype(np.float64)
+
+        # Carrier squelch: measure CNR on channel-filtered envelope
+        self._cnr_metric.process(envelope)
 
         # AM AGC: the raw envelope scales with RF level, so without this the
         # audio level swings with signal strength and is far quieter than the

--- a/core/dsp/pipeline.py
+++ b/core/dsp/pipeline.py
@@ -21,6 +21,9 @@ from core.dsp.filters import StatefulDecimator
 from core.dsp.mixer import Mixer
 from core.dsp.noise_blanker import NoiseBlanker
 from core.dsp.spectrum import SpectrumAnalyser
+from core.dsp.squelch_metric import (
+    AdaptiveNoiseFloor, AMAutoThreshold, FMAutoThreshold, sensitivity_to_margins,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,8 @@ class PipelineCallbacks:
     on_spectrum: Optional[Callable[[np.ndarray], None]] = None
     on_stereo_change: Optional[Callable[[bool], None]] = None
     on_rds_station: Optional[Callable[[str], None]] = None
+    noise_db_setter: Optional[Callable[[float], None]] = None
+    auto_squelch_threshold_setter: Optional[Callable[[float], None]] = None
 
 
 class DSPPipeline:
@@ -122,6 +127,13 @@ class DSPPipeline:
         # WFM kwargs for mode rebuilds
         self._wfm_kwargs = wfm_kwargs or {}
 
+        # Adaptive noise floor for non-FM auto squelch
+        self._adaptive_floor = AdaptiveNoiseFloor()
+        # FM carrier squelch auto threshold
+        self._fm_auto_threshold = FMAutoThreshold()
+        # AM carrier-to-noise auto threshold
+        self._am_auto_threshold = AMAutoThreshold()
+
     @property
     def baseband_rate(self) -> int:
         return self._baseband_rate
@@ -133,6 +145,13 @@ class DSPPipeline:
     @property
     def demodulator(self) -> Demodulator:
         return self._demodulator
+
+    def set_squelch_sensitivity(self, sensitivity: int) -> None:
+        """Update the squelch margin/headroom from a sensitivity level (0–10)."""
+        m = sensitivity_to_margins(sensitivity)
+        self._fm_auto_threshold.set_margin(m["fm_margin"])
+        self._am_auto_threshold.set_margin(m["am_margin"])
+        self._adaptive_floor.set_headroom(m["rssi_headroom"])
 
     def set_mode(
         self,
@@ -201,6 +220,9 @@ class DSPPipeline:
             )
             self._dsp_stereo = None
             self._stereo_delay = 0
+            self._adaptive_floor.reset()
+            self._fm_auto_threshold.reset()
+            self._am_auto_threshold.reset()
 
         # Handle retune
         if self._retune_pending:
@@ -212,6 +234,14 @@ class DSPPipeline:
             rds = getattr(self._demodulator, "_rds", None)
             if rds is not None:
                 rds.reset()
+            # Reset the noise metric smoother so stale values from the
+            # previous frequency don't keep the squelch gate open.
+            noise_metric = getattr(self._demodulator, "_noise_metric", None)
+            if noise_metric is not None:
+                noise_metric.reset()
+            cnr_metric = getattr(self._demodulator, "_cnr_metric", None)
+            if cnr_metric is not None:
+                cnr_metric.reset()
 
         # DC offset removal
         iq = iq - np.mean(iq)
@@ -236,6 +266,35 @@ class DSPPipeline:
         bb = self._decimator.process(mixed)
         audio = self._demodulator.process(bb)
         self._audio_write(audio)
+
+        # Auto squelch metric — three strategies by mode:
+        #   FM (WFM/NFM): carrier squelch via above-audio noise
+        #   AM/DSB: carrier-to-noise ratio on channel-filtered envelope
+        #   SSB/CW: adaptive RSSI noise floor tracking
+        noise_db_val = getattr(self._demodulator, "noise_db", None)
+        cnr_db_val = getattr(self._demodulator, "cnr_db", None)
+        if noise_db_val is not None:
+            # FM mode — forward the carrier squelch noise reading + threshold
+            if self._cb.noise_db_setter is not None:
+                self._cb.noise_db_setter(noise_db_val)
+            if self._cb.auto_squelch_threshold_setter is not None:
+                self._cb.auto_squelch_threshold_setter(
+                    self._fm_auto_threshold.update(noise_db_val))
+        elif cnr_db_val is not None:
+            # AM mode — forward the carrier-to-noise ratio + threshold
+            if self._cb.noise_db_setter is not None:
+                self._cb.noise_db_setter(cnr_db_val)
+            if self._cb.auto_squelch_threshold_setter is not None:
+                self._cb.auto_squelch_threshold_setter(
+                    self._am_auto_threshold.update(cnr_db_val))
+        else:
+            # SSB/CW — feed RSSI into adaptive noise floor tracker
+            rssi = 10.0 * np.log10(max(iq_power, 1e-10))
+            auto_thr = self._adaptive_floor.update(rssi)
+            if self._cb.noise_db_setter is not None:
+                self._cb.noise_db_setter(rssi)
+            if self._cb.auto_squelch_threshold_setter is not None:
+                self._cb.auto_squelch_threshold_setter(auto_thr)
 
         # Stereo/RDS tracking (WFM only)
         if self._mode == "WFM":

--- a/core/dsp/squelch_metric.py
+++ b/core/dsp/squelch_metric.py
@@ -1,0 +1,244 @@
+"""core/dsp/squelch_metric.py — Hardware-style squelch metrics.
+
+Three strategies:
+
+* **FMNoiseMetric** (carrier squelch) — for WFM/NFM.  Measures noise energy
+  *above* the audio band in the FM discriminator output.  When a valid FM
+  signal is present the discriminator is quiet above the audio passband;
+  when only noise is received the discriminator is wideband white noise.
+  Lower ``noise_db`` ⇒ stronger signal.
+
+* **AMCarrierMetric** (carrier-to-noise ratio) — for AM/DSB.  Measures the
+  ratio of carrier level to noise on the channel-filtered IQ envelope.
+  Hardware airband receivers detect the AM carrier presence this way
+  rather than using broadband RSSI.  Higher ``cnr_db`` ⇒ stronger signal.
+
+* **AdaptiveNoiseFloor** — for SSB/CW (no carrier to detect).  Tracks the
+  RSSI noise floor with a slow IIR follower and returns an automatic
+  squelch threshold (noise floor + configurable headroom).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import signal as sp_signal
+
+from .filters import make_bandpass_iir
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity → margin mapping
+# ---------------------------------------------------------------------------
+
+def sensitivity_to_margins(sensitivity: int) -> dict[str, float]:
+    """Map a sensitivity level (0–10) to per-strategy margin/headroom values.
+
+    0 = most sensitive (weakest signals open squelch).
+    10 = tightest (only strong signals).
+    """
+    s = max(0, min(10, sensitivity))
+    return {
+        "fm_margin": 2.0 + s * 1.5,      # 2–17 dB
+        "am_margin": 1.0 + s * 0.8,      # 1–9 dB
+        "rssi_headroom": 4.0 + s * 2.0,  # 4–24 dB
+    }
+
+
+# ---------------------------------------------------------------------------
+# FM carrier squelch
+# ---------------------------------------------------------------------------
+
+# Default noise-measurement bands (Hz) per mode — chosen to sit above the
+# audio passband but below interfering subcarriers.
+_NOISE_BANDS: dict[str, tuple[float, float]] = {
+    "NFM": (4_000.0, 6_000.0),   # above 3 kHz voice, below 8 kHz LPF
+    "WFM": (16_000.0, 18_500.0), # above 15 kHz audio, below 19 kHz pilot
+}
+
+
+class FMNoiseMetric:
+    """Stateful above-audio noise power meter for FM carrier squelch."""
+
+    def __init__(self, baseband_rate: int, mode: str,
+                 noise_band: tuple[float, float] | None = None) -> None:
+        lo, hi = noise_band if noise_band is not None else _NOISE_BANDS[mode]
+        self._sos = make_bandpass_iir(lo, hi, baseband_rate, order=3)
+        self._zi = sp_signal.sosfilt_zi(self._sos) * 0.0
+        # IIR-smoothed noise power (dB).  Start high so squelch is closed
+        # until the first few chunks settle the estimate.
+        self._smooth_db: float = 20.0
+        # Smoothing alpha — ~70 ms time constant at ~37 chunks/s
+        self._alpha: float = 0.15
+
+    def process(self, discriminator: np.ndarray) -> float:
+        """Feed discriminator output, return smoothed noise power in dB.
+
+        Lower values ⇒ stronger FM signal (less above-audio noise).
+        """
+        filtered, self._zi = sp_signal.sosfilt(
+            self._sos, discriminator, zi=self._zi,
+        )
+        rms_power = float(np.mean(np.square(filtered)))
+        noise_db = 10.0 * np.log10(max(rms_power, 1e-20))
+        self._smooth_db += self._alpha * (noise_db - self._smooth_db)
+        return self._smooth_db
+
+    def reset(self) -> None:
+        self._zi = sp_signal.sosfilt_zi(self._sos) * 0.0
+        # Reset to a high value (noise-like) so the squelch starts closed
+        # and must detect a real signal to open.
+        self._smooth_db = 20.0
+
+
+# ---------------------------------------------------------------------------
+# AM carrier-to-noise squelch
+# ---------------------------------------------------------------------------
+
+class AMCarrierMetric:
+    """Carrier-to-noise ratio meter for AM squelch.
+
+    Operates on the channel-filtered IQ envelope (already computed by the
+    AM demodulator).  When an AM carrier is present the envelope has a
+    large mean (the carrier) with variance from modulation + noise.
+    When no carrier is present the envelope is rectified noise with a
+    small, noisy mean.
+
+    The metric is ``cnr_db = 10·log10(mean² / var)``.  A strong
+    unmodulated carrier gives CNR ≫ 20 dB; noise-only gives CNR ≈ 1–5 dB.
+    Modulated voice typically gives 8–15 dB depending on modulation depth.
+
+    Higher cnr_db ⇒ stronger signal (same polarity as RSSI, unlike FM
+    noise metric which is inverted).
+    """
+
+    def __init__(self) -> None:
+        self._smooth_db: float = 0.0
+        self._alpha: float = 0.15  # ~70 ms time constant at ~37 chunks/s
+
+    def process(self, envelope: np.ndarray) -> float:
+        """Feed the IQ envelope (|IQ|), return smoothed CNR in dB."""
+        mean_sq = float(np.mean(envelope)) ** 2
+        var = float(np.var(envelope))
+        # CNR = carrier power / noise+modulation power
+        cnr = mean_sq / max(var, 1e-20)
+        cnr_db = 10.0 * np.log10(max(cnr, 1e-10))
+        self._smooth_db += self._alpha * (cnr_db - self._smooth_db)
+        return self._smooth_db
+
+    def reset(self) -> None:
+        self._smooth_db = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Adaptive thresholds
+# ---------------------------------------------------------------------------
+
+class FMAutoThreshold:
+    """Adaptive threshold for FM carrier squelch.
+
+    Tracks the *noise ceiling* — the noise_db level when no signal is
+    present — and sets the squelch threshold below it by ``margin_db``.
+    Squelch opens when noise_db drops below the threshold (signal present
+    pushes noise down).
+
+    The ceiling eagerly chases *upward* (toward noise-only levels) and
+    drifts downward very slowly, so it adapts to environmental changes
+    without chasing signals.
+    """
+
+    def __init__(self, margin_db: float = 9.5) -> None:
+        self._margin = margin_db
+        self._ceiling: float | None = None
+        self._alpha_up: float = 0.08     # chase upward quickly (noise appeared)
+        self._alpha_down: float = 0.0005 # drift downward very slowly
+
+    def set_margin(self, margin_db: float) -> None:
+        self._margin = margin_db
+
+    def update(self, noise_db: float) -> float:
+        """Feed noise_db, return the auto squelch threshold.
+
+        The threshold sits *below* the noise ceiling.  noise_db < threshold
+        means a signal is present (noise dropped).
+        """
+        if self._ceiling is None:
+            self._ceiling = noise_db
+        elif noise_db > self._ceiling:
+            # Noise level rose — track up quickly
+            self._ceiling += self._alpha_up * (noise_db - self._ceiling)
+        else:
+            # Signal present or environment quieter — drift down slowly
+            self._ceiling += self._alpha_down * (noise_db - self._ceiling)
+        return self._ceiling - self._margin
+
+    def reset(self) -> None:
+        self._ceiling = None
+
+
+class AMAutoThreshold:
+    """Adaptive threshold for AM carrier squelch.
+
+    Tracks the *high* end of the CNR metric (noise-only ceiling) and
+    sets the threshold a margin above it.  When no signal is present,
+    CNR is low (~1–5 dB); when a signal is present, CNR is high.
+    """
+
+    def __init__(self, margin_db: float = 5.0) -> None:
+        self._margin = margin_db
+        self._ceiling: float | None = None
+        self._alpha_fast: float = 0.05
+        self._alpha_slow: float = 0.002
+
+    def set_margin(self, margin_db: float) -> None:
+        self._margin = margin_db
+
+    def update(self, cnr_db: float) -> float:
+        """Feed CNR, return the auto squelch threshold."""
+        if self._ceiling is None:
+            self._ceiling = cnr_db
+        elif cnr_db < self._ceiling + self._margin:
+            # Near or below ceiling (noise only) — track quickly
+            self._ceiling += self._alpha_fast * (cnr_db - self._ceiling)
+        else:
+            # Signal present — let ceiling drift up very slowly
+            self._ceiling += self._alpha_slow * (cnr_db - self._ceiling)
+        return self._ceiling + self._margin
+
+    def reset(self) -> None:
+        self._ceiling = None
+
+
+class AdaptiveNoiseFloor:
+    """Tracks the RSSI noise floor and returns an automatic squelch threshold.
+
+    The floor estimate converges quickly when the channel is quiet and
+    drifts slowly downward when a signal is present, so the threshold
+    adapts to changing environmental conditions without manual adjustment.
+    """
+
+    def __init__(self, headroom_db: float = 14.0, guard_db: float = 6.0) -> None:
+        self._headroom = headroom_db
+        self._guard = guard_db
+        self._floor: float | None = None
+        # Fast alpha — used when measured RSSI is near the current floor
+        self._alpha_fast: float = 0.05
+        # Slow alpha — lets the floor drift down when signal is present
+        self._alpha_slow: float = 0.001
+
+    def set_headroom(self, headroom_db: float) -> None:
+        self._headroom = headroom_db
+
+    def update(self, rssi_db: float) -> float:
+        """Feed an RSSI reading, return the auto squelch threshold (dB)."""
+        if self._floor is None:
+            self._floor = rssi_db
+        elif rssi_db < self._floor + self._guard:
+            # Near or below current floor — track quickly
+            self._floor += self._alpha_fast * (rssi_db - self._floor)
+        else:
+            # Signal present — let the floor drift down very slowly
+            self._floor += self._alpha_slow * (rssi_db - self._floor)
+        return self._floor + self._headroom
+
+    def reset(self) -> None:
+        self._floor = None

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -52,6 +52,7 @@ class Scanner:
         set_frequency_cb: Callable[[int], None],
         get_signal_db_cb: Callable[[], float],
         dispatcher: Callable = lambda f, *a, **kw: f(*a, **kw),
+        get_squelch_open_cb: Optional[Callable[[], bool]] = None,
     ) -> None:
         """
         Parameters
@@ -62,10 +63,14 @@ class Scanner:
             Callable that returns the current peak signal in dBm.
         dispatcher:
             Used to push callbacks to the UI thread (typically wx.CallAfter).
+        get_squelch_open_cb:
+            Callable returning True when the auto squelch gate considers
+            a signal present.  Used for signal detection during scanning.
         """
         self._set_freq = set_frequency_cb
         self._get_signal = get_signal_db_cb
         self._dispatch = dispatcher
+        self._get_squelch_open = get_squelch_open_cb
 
         self._thread: Optional[threading.Thread] = None
         self._running = False
@@ -88,7 +93,6 @@ class Scanner:
         start_hz: int,
         stop_hz: int,
         step_hz: int,
-        squelch_db: float = -80.0,
     ) -> None:
         """Scan a frequency range from *start_hz* to *stop_hz* in *step_hz* steps.
 
@@ -101,22 +105,20 @@ class Scanner:
         while freq <= stop_hz:
             targets.append((freq, ""))
             freq += step_hz
-        self.start_targets(targets, squelch_db)
+        self.start_targets(targets)
 
     def start_list(
         self,
         freqs: List[int],
-        squelch_db: float = -80.0,
         labels: Optional[List[str]] = None,
     ) -> None:
         """Scan a discrete list of frequencies (channel-map / memory scan)."""
         labels = labels or [""] * len(freqs)
-        self.start_targets(list(zip(freqs, labels)), squelch_db)
+        self.start_targets(list(zip(freqs, labels)))
 
     def start_targets(
         self,
         targets: List[Tuple[int, str]],
-        squelch_db: float = -80.0,
     ) -> None:
         """Scan an explicit list of ``(freq_hz, label)`` targets."""
         if self._running:
@@ -129,7 +131,7 @@ class Scanner:
 
         self._thread = threading.Thread(
             target=self._scan_loop,
-            args=(list(targets), squelch_db),
+            args=(list(targets),),
             daemon=True,
             name="Scanner",
         )
@@ -161,7 +163,6 @@ class Scanner:
     def _scan_loop(
         self,
         targets: List[Tuple[int, str]],
-        squelch_db: float,
     ) -> None:
         i = 0
         n = len(targets)
@@ -186,9 +187,14 @@ class Scanner:
             if not self._running:
                 break
 
-            # Check signal
+            # Check signal via the live auto squelch gate
             strength = self._get_signal()
-            if strength >= squelch_db:
+            signal_found = (
+                self._get_squelch_open()
+                if self._get_squelch_open is not None
+                else False
+            )
+            if signal_found:
                 result = ScanResult(freq_hz=freq, strength_db=strength, label=label)
                 self.results.append(result)
                 logger.info("Signal found: %s", result)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -37,7 +37,7 @@ def test_load_missing_seeds_defaults(tmp_path):
 
 def test_default_maps_include_pmr_and_cb():
     names = [m.name for m in default_maps()]
-    assert names == ["My Channels", "PMR446", "CB (CEPT FM)"]
+    assert names == ["My Channels", "PMR446", "CB (CEPT FM)", "CB (CEPT AM)"]
 
 
 def test_pmr446_map():
@@ -49,15 +49,18 @@ def test_pmr446_map():
 
 
 def test_cb_cept_map():
-    cb = next(m for m in default_maps() if m.name == "CB (CEPT FM)")
-    assert len(cb.channels) == 40
-    assert cb.channels[0].frequency == 26_965_000    # ch1
-    assert cb.channels[39].frequency == 27_405_000   # ch40
+    cb_fm = next(m for m in default_maps() if m.name == "CB (CEPT FM)")
+    assert len(cb_fm.channels) == 40
+    assert cb_fm.channels[0].frequency == 26_965_000    # ch1
+    assert cb_fm.channels[39].frequency == 27_405_000   # ch40
     # The standard CB anomaly: ch23 is higher than ch24/25.
-    assert cb.channels[22].frequency == 27_255_000   # ch23
-    assert cb.channels[23].frequency == 27_235_000   # ch24
-    assert cb.channels[24].frequency == 27_245_000   # ch25
-    assert all(c.mode == "NFM" for c in cb.channels)
+    assert cb_fm.channels[22].frequency == 27_255_000   # ch23
+    assert cb_fm.channels[23].frequency == 27_235_000   # ch24
+    assert cb_fm.channels[24].frequency == 27_245_000   # ch25
+    assert all(c.mode == "NFM" for c in cb_fm.channels)
+    cb_am = next(m for m in default_maps() if m.name == "CB (CEPT AM)")
+    assert len(cb_am.channels) == 40
+    assert all(c.mode == "AM" for c in cb_am.channels)
 
 
 def test_round_trip(tmp_path):
@@ -100,7 +103,7 @@ def test_load_merges_new_default_maps(tmp_path):
     fresh.load(path)
     names = [m.name for m in fresh.maps]
     assert names[0] == "Mine"                    # user's map preserved/first
-    assert "PMR446" in names and "CB (CEPT FM)" in names  # defaults merged in
+    assert "PMR446" in names and "CB (CEPT FM)" in names and "CB (CEPT AM)" in names
 
 
 def test_set_active_clamps():

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -47,13 +47,13 @@ def test_save_channel_with_squelch_and_overrides(wx_app):
     panel._freq_ctrl.SetValue("145.5")
     panel._mode_ctrl.SetStringSelection("NFM")
     panel._refresh_bw_choices("NFM")
-    panel._squelch_ctrl.SetValue("-70")
+    panel._squelch_ctrl.SetValue("7")
     panel._pending_overrides = {"nfm_deviation": 2500}
     panel._on_save_channel(None)
     ch = store.maps[0].channels[0]
     assert ch.number == 5
     assert ch.frequency == 145_500_000
-    assert ch.squelch == -70.0
+    assert ch.squelch_sensitivity == 7
     assert ch.nfm_deviation == 2500
     frame.Destroy()
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -12,9 +12,10 @@ def test_band_range_scan_tunes_expected_freqs(monkeypatch):
     tuned = []
     sc = Scanner(
         set_frequency_cb=lambda f: tuned.append(f),
-        get_signal_db_cb=lambda: -200.0,  # below squelch → nothing "found"
+        get_signal_db_cb=lambda: -200.0,
+        get_squelch_open_cb=lambda: False,  # nothing "found"
     )
-    sc.start(100_000_000, 100_200_000, 100_000, squelch_db=-60.0)
+    sc.start(100_000_000, 100_200_000, 100_000)
     sc._thread.join(timeout=5)
 
     assert tuned == [100_000_000, 100_100_000, 100_200_000]
@@ -29,13 +30,14 @@ def test_channel_list_scan_reports_labels(monkeypatch):
     found = []
     sc = Scanner(
         set_frequency_cb=lambda f: tuned.append(f),
-        get_signal_db_cb=lambda: -10.0,  # above squelch → every target "found"
+        get_signal_db_cb=lambda: -10.0,
+        get_squelch_open_cb=lambda: True,  # every target "found"
     )
     sc.on_signal_found = found.append
 
     freqs = [446_006_250, 446_018_750, 446_031_250]
     labels = ["CH1 Alpha", "CH2 Bravo", "CH3 Charlie"]
-    sc.start_list(freqs, squelch_db=-60.0, labels=labels)
+    sc.start_list(freqs, labels)
     sc._thread.join(timeout=5)
 
     assert tuned == freqs
@@ -52,8 +54,9 @@ def test_zero_step_falls_back(monkeypatch):
     sc = Scanner(
         set_frequency_cb=lambda f: tuned.append(f),
         get_signal_db_cb=lambda: -200.0,
+        get_squelch_open_cb=lambda: False,
     )
-    sc.start(100_000_000, 100_050_000, 0, squelch_db=-60.0)
+    sc.start(100_000_000, 100_050_000, 0)
     sc._thread.join(timeout=5)
 
     # Fallback step is 100 kHz → just the start frequency fits in this range.

--- a/ui/dialogs/scanner_dialog.py
+++ b/ui/dialogs/scanner_dialog.py
@@ -103,13 +103,6 @@ class ScannerDialog(wx.Frame):
         self._map_choice.Bind(wx.EVT_CHOICE, lambda e: self._update_info())
         grid.Add(self._map_choice, 1, wx.EXPAND)
 
-        # Squelch threshold
-        grid.Add(wx.StaticText(panel, label=_("Squelch (dBm):")), 0, wx.ALIGN_CENTER_VERTICAL)
-        self._squelch = wx.SpinCtrl(
-            panel, value="-60", min=-120, max=0, name="Scan squelch threshold dBm"
-        )
-        grid.Add(self._squelch, 1, wx.EXPAND)
-
         src_sizer.Add(grid, 0, wx.EXPAND | wx.ALL, 6)
 
         self._info = wx.StaticText(panel, label="", name="Scan range")
@@ -215,7 +208,6 @@ class ScannerDialog(wx.Frame):
     # ------------------------------------------------------------------
 
     def _on_start(self, _event: wx.CommandEvent) -> None:
-        squelch = float(self._squelch.GetValue())
         self._results_list.DeleteAllItems()
 
         if self._source.GetSelection() == _SRC_BAND:
@@ -226,7 +218,7 @@ class ScannerDialog(wx.Frame):
             step = band.step if band.step > 0 else _DEFAULT_STEP_HZ
             self._set_mode(band.mode)
             self._status.SetLabel(_("Scanning band {name}…").format(name=band.name))
-            self._scanner.start(band.freq_start, band.freq_end, step, squelch)
+            self._scanner.start(band.freq_start, band.freq_end, step)
             speech.output(
                 _("Scanning band {name}, {start} to {stop}.").format(
                     name=band.name,
@@ -243,9 +235,6 @@ class ScannerDialog(wx.Frame):
             if not chans:
                 speech.output(_("This channel map is empty."))
                 return
-            # Set the demod mode from the first channel so a stop on a hit is
-            # audible.  (Detection itself is mode-independent — it reads the
-            # spectrum peak.)
             self._set_mode(chans[0].mode)
             freqs = [c.frequency for c in chans]
             labels = [
@@ -253,7 +242,7 @@ class ScannerDialog(wx.Frame):
                 for c in chans
             ]
             self._status.SetLabel(_("Scanning map {name}…").format(name=cmap.name))
-            self._scanner.start_list(freqs, squelch, labels)
+            self._scanner.start_list(freqs, labels)
             speech.output(
                 _("Scanning channel map {name}, {count} channels.").format(
                     name=cmap.name, count=len(chans)

--- a/ui/keyboard_handler.py
+++ b/ui/keyboard_handler.py
@@ -36,7 +36,6 @@ SCENE_NEXT = "scene_next"
 
 # --- Radio control ---
 START_STOP = "start_stop"
-TOGGLE_PAUSE = "toggle_pause"
 TOGGLE_MUTE = "toggle_mute"
 TOGGLE_RECORDING = "toggle_recording"
 
@@ -48,6 +47,8 @@ VOLUME_UP = "volume_up"
 VOLUME_DOWN = "volume_down"
 SQUELCH_UP = "squelch_up"
 SQUELCH_DOWN = "squelch_down"
+SQUELCH_TOGGLE = "squelch_toggle"
+SQUELCH_MONITOR = "squelch_monitor"
 
 # --- Sonification / spectrum ---
 SNAPSHOT = "snapshot"
@@ -99,8 +100,6 @@ def _build_keymap() -> dict[tuple[int, int], str]:
     km: dict[tuple[int, int], str] = {
         # Radio control
         (wx.WXK_F2, NONE):           START_STOP,
-        (wx.WXK_SPACE, NONE):        TOGGLE_PAUSE,
-        (wx.WXK_SPACE, M):           TOGGLE_PAUSE,
         (wx.WXK_F3, NONE):           TOGGLE_MUTE,
 
         # Frequency
@@ -130,6 +129,10 @@ def _build_keymap() -> dict[tuple[int, int], str]:
         (wx.WXK_F12, NONE):         VOLUME_DOWN,
         (wx.WXK_F11, S):            SQUELCH_UP,
         (wx.WXK_F12, S):            SQUELCH_DOWN,
+        (ord("A"), M | S):          SQUELCH_TOGGLE,
+        (wx.WXK_F4, M):             SQUELCH_TOGGLE,
+        (ord("L"), NONE):            SQUELCH_MONITOR,
+        (wx.WXK_F4, NONE):          SQUELCH_MONITOR,
 
         # Sonification
         (wx.WXK_F5, NONE):          SNAPSHOT,

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -64,7 +64,7 @@ class MainWindow(wx.Frame):
             blocksize=self._settings.audio_buffer_size,
         )
         self._audio.volume = self._settings.volume
-        self._audio.squelch = self._settings.squelch
+        self._audio.squelch_enabled = self._settings.squelch_enabled
         self._audio.squelch_hysteresis_db = self._settings.squelch_hysteresis_db
         self._audio.squelch_hang_ms = self._settings.squelch_hang_ms
         self._audio.muted = self._settings.muted
@@ -85,6 +85,7 @@ class MainWindow(wx.Frame):
             set_frequency_cb=self._tune,
             get_signal_db_cb=lambda: self._audio.signal_db,
             dispatcher=wx.CallAfter,
+            get_squelch_open_cb=lambda: self._audio._sq_open,
         )
         self._scenes = SceneStore()
         self._scenes.load()
@@ -140,6 +141,7 @@ class MainWindow(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self._on_close)
         self.Bind(wx.EVT_CHAR_HOOK, self._on_key)
+        self.Bind(wx.EVT_KEY_UP, self._on_key_up)
 
         self._apply_settings_to_ui()
 
@@ -248,21 +250,34 @@ class MainWindow(wx.Frame):
 
         # --- Squelch row ---
         sq_row = wx.BoxSizer(wx.HORIZONTAL)
-        sq_label = wx.StaticText(panel, label=_("Squelch (dBm):"))
+        sq_label = wx.StaticText(panel, label=_("Squelch:"))
         self._sq_slider = wx.Slider(
-            panel, value=int(self._settings.squelch),
-            minValue=-120, maxValue=0,
+            panel, value=self._settings.squelch_sensitivity,
+            minValue=0, maxValue=10,
             style=wx.SL_HORIZONTAL,
-            name="Squelch slider",
+            name="Squelch sensitivity slider",
             size=(140, -1),
         )
         self._sq_slider.Bind(wx.EVT_SLIDER, self._on_squelch)
         self._sq_lbl = wx.StaticText(
-            panel, label=f"{self._settings.squelch:.0f} dBm", name="Squelch level display"
+            panel,
+            label=str(self._settings.squelch_sensitivity),
+            name="Squelch sensitivity display",
         )
-        for w in (sq_label, self._sq_slider, self._sq_lbl):
+        self._sq_off_btn = wx.ToggleButton(
+            panel,
+            label=_("Off (Ctrl+Shift+A)"),
+            name="Squelch off toggle",
+        )
+        self._sq_off_btn.SetValue(not self._settings.squelch_enabled)
+        self._sq_off_btn.Bind(wx.EVT_TOGGLEBUTTON, self._on_squelch_off_toggle)
+        if not self._settings.squelch_enabled:
+            self._sq_slider.Enable(False)
+            self._sq_lbl.SetLabel(_("Off"))
+        for w in (sq_label, self._sq_slider, self._sq_lbl, self._sq_off_btn):
             sq_row.Add(w, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
         outer.Add(sq_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
+        self._monitor_active: bool = False
 
         # --- Sweep toggle button ---
         sweep_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -362,8 +377,8 @@ class MainWindow(wx.Frame):
         self._update_bw_choices(self._settings.mode)
         self._vol_slider.SetValue(int(self._settings.volume * 100))
         self._mute_btn.SetValue(self._settings.muted)
-        self._sq_slider.SetValue(int(self._settings.squelch))
-        self._sq_lbl.SetLabel(f"{self._settings.squelch:.0f} dBm")
+        self._sq_slider.SetValue(self._settings.squelch_sensitivity)
+        self._sq_lbl.SetLabel(str(self._settings.squelch_sensitivity))
         # Reflect the restored band / mode / channel context immediately.
         self._update_context_anchor()
 
@@ -559,14 +574,11 @@ class MainWindow(wx.Frame):
         else:
             self._load_channel(res.channel)
 
-    def _apply_squelch_override(self, value) -> None:
-        """Apply a band/channel squelch override (dBm) to audio + UI."""
+    def _apply_sensitivity_override(self, value) -> None:
+        """Apply a band/channel squelch sensitivity override (0–10)."""
         if value is None:
             return
-        self._settings.squelch = value
-        self._audio.squelch = value
-        self._sq_slider.SetValue(int(value))
-        self._sq_lbl.SetLabel(f"{value:.0f} dBm")
+        self._apply_sensitivity(value)
 
     def _load_channel(self, ch: Channel) -> None:
         """Tune to a channel and announce number, label, frequency."""
@@ -574,7 +586,7 @@ class MainWindow(wx.Frame):
         self._set_mode(ch.mode)
         self._set_bandwidth(ch.bandwidth)
         self._apply_mode_overrides(ch)
-        self._apply_squelch_override(ch.squelch)
+        self._apply_sensitivity_override(ch.squelch_sensitivity)
         self._tune(ch.frequency)
         self._persist_op_state()
         speech.output(
@@ -594,7 +606,7 @@ class MainWindow(wx.Frame):
         self._set_mode(scene.mode)
         self._set_bandwidth(scene.bandwidth)
         self._apply_mode_overrides(scene)
-        self._apply_squelch_override(scene.squelch)
+        self._apply_sensitivity_override(scene.squelch_sensitivity)
         landing = scene.landing_freq()
         if landing is not None:
             self._cursor.reset_offset()
@@ -624,9 +636,7 @@ class MainWindow(wx.Frame):
     # ==================================================================
 
     def _on_start_stop(self, _event: wx.CommandEvent) -> None:
-        if self._radio.paused:
-            self._stop_radio()
-        elif self._radio.running:
+        if self._radio.running:
             self._stop_radio()
         else:
             self._start_radio()
@@ -656,27 +666,6 @@ class MainWindow(wx.Frame):
         self._start_btn.SetLabel(_("\u25b6 Start"))
         self._statusbar.SetStatusText(_("Stopped."))
         speech.output(_("Radio stopped."))
-
-    def _toggle_pause(self) -> None:
-        """Toggle pause/resume."""
-        if not self._radio.running and not self._radio.paused:
-            return
-        if not self._radio.paused:
-            self._radio.pause()
-            listen = self._cursor.listening_freq()
-            self._start_btn.SetLabel(_("▶ Resume"))
-            self._statusbar.SetStatusText(
-                _("Paused — {freq}").format(freq=fmt_freq(listen))
-            )
-            speech.output(_("Paused."))
-        else:
-            self._radio.resume()
-            listen = self._cursor.listening_freq()
-            self._start_btn.SetLabel(_("■ Stop"))
-            self._statusbar.SetStatusText(
-                _("Receiving — {freq}").format(freq=fmt_freq(listen))
-            )
-            speech.output(_("Resumed."))
 
     # ==================================================================
     # DSP pipeline callbacks (dispatched to UI thread)
@@ -760,11 +749,18 @@ class MainWindow(wx.Frame):
         speech.output(_("Muted") if muted else _("Unmuted"))
 
     def _on_squelch(self, event: wx.CommandEvent) -> None:
-        val = float(event.GetInt())
-        self._audio.squelch = val
-        self._settings.squelch = val
-        self._sq_lbl.SetLabel(f"{val:.0f} dBm")
-        speech.output(_("Squelch {val:.0f} dBm").format(val=val))
+        val = event.GetInt()
+        self._apply_sensitivity(val)
+
+    def _apply_sensitivity(self, val: int) -> None:
+        """Set squelch sensitivity and update pipeline + UI."""
+        val = max(0, min(10, val))
+        self._settings.squelch_sensitivity = val
+        self._sq_slider.SetValue(val)
+        self._sq_lbl.SetLabel(str(val))
+        if self._radio.pipeline is not None:
+            self._radio.pipeline.set_squelch_sensitivity(val)
+        speech.output(_("Squelch {val}").format(val=val))
 
     def _adjust_volume(self, delta_pct: int) -> None:
         """Change volume by *delta_pct* percentage points and announce."""
@@ -775,14 +771,53 @@ class MainWindow(wx.Frame):
         self._vol_slider.SetValue(pct)
         speech.output(_("Volume {v} percent").format(v=pct))
 
-    def _adjust_squelch(self, delta_db: int) -> None:
-        """Change squelch by *delta_db* dB and announce."""
-        val = max(-120.0, min(0.0, self._settings.squelch + delta_db))
-        self._audio.squelch = val
-        self._settings.squelch = val
-        self._sq_slider.SetValue(int(val))
-        self._sq_lbl.SetLabel(f"{val:.0f} dBm")
-        speech.output(_("Squelch {val:.0f} dBm").format(val=val))
+    def _adjust_squelch(self, delta: int) -> None:
+        """Change squelch sensitivity by *delta* and announce."""
+        if not self._settings.squelch_enabled:
+            return
+        self._apply_sensitivity(self._settings.squelch_sensitivity + delta)
+
+    def _set_squelch_enabled(self, enabled: bool) -> None:
+        """Enable or disable squelch."""
+        self._settings.squelch_enabled = enabled
+        self._audio.squelch_enabled = enabled
+        self._sq_off_btn.SetValue(not enabled)
+        if enabled:
+            self._sq_slider.Enable(True)
+            self._sq_lbl.SetLabel(str(self._settings.squelch_sensitivity))
+            speech.output(_("Squelch on"))
+        else:
+            self._sq_slider.Enable(False)
+            self._sq_lbl.SetLabel(_("Off"))
+            speech.output(_("Squelch off"))
+
+    def _on_squelch_off_toggle(self, event: wx.CommandEvent) -> None:
+        self._set_squelch_enabled(not event.IsChecked())
+
+    def _toggle_squelch(self) -> None:
+        self._set_squelch_enabled(not self._settings.squelch_enabled)
+
+    def _monitor_down(self) -> None:
+        """Momentary squelch defeat — hold to listen."""
+        if self._monitor_active:
+            return
+        self._monitor_active = True
+        self._audio.squelch_enabled = False
+        speech.output(_("Monitor"))
+        # Poll as backup in case key-up event is lost
+        if not hasattr(self, "_monitor_timer"):
+            self._monitor_timer = wx.Timer(self)
+            self.Bind(wx.EVT_TIMER, lambda e: self._poll_monitor_key(), self._monitor_timer)
+        self._monitor_timer.Start(100)  # check every 100ms
+
+    def _monitor_up(self) -> None:
+        """Release monitor — restore squelch."""
+        if not self._monitor_active:
+            return
+        self._monitor_active = False
+        self._audio.squelch_enabled = self._settings.squelch_enabled
+        if hasattr(self, "_monitor_timer"):
+            self._monitor_timer.Stop()
 
     # ==================================================================
     # Noise blanker
@@ -855,6 +890,7 @@ class MainWindow(wx.Frame):
             kb.START_STOP, kb.TOGGLE_MUTE,
             kb.VOLUME_UP, kb.VOLUME_DOWN,
             kb.SQUELCH_UP, kb.SQUELCH_DOWN,
+            kb.SQUELCH_TOGGLE, kb.SQUELCH_MONITOR,
         }
         if action in global_actions:
             self._dispatch_action(action)
@@ -903,7 +939,6 @@ class MainWindow(wx.Frame):
         return {
             # Radio control
             kb.START_STOP:          lambda: self._on_start_stop(None),
-            kb.TOGGLE_PAUSE:        self._toggle_pause,
             kb.TOGGLE_MUTE:         self._toggle_mute_action,
             kb.TOGGLE_RECORDING:    self._toggle_recording,
             # Frequency
@@ -927,8 +962,10 @@ class MainWindow(wx.Frame):
             # Volume / squelch
             kb.VOLUME_UP:           lambda: self._adjust_volume(+5),
             kb.VOLUME_DOWN:         lambda: self._adjust_volume(-5),
-            kb.SQUELCH_UP:          lambda: self._adjust_squelch(+3),
-            kb.SQUELCH_DOWN:        lambda: self._adjust_squelch(-3),
+            kb.SQUELCH_UP:          lambda: self._adjust_squelch(+1),
+            kb.SQUELCH_DOWN:        lambda: self._adjust_squelch(-1),
+            kb.SQUELCH_TOGGLE:      self._toggle_squelch,
+            kb.SQUELCH_MONITOR:     self._monitor_down,
             # Sonification
             kb.SNAPSHOT:            self._do_snapshot,
             kb.TOGGLE_SWEEP:        self._toggle_sweep,
@@ -962,6 +999,21 @@ class MainWindow(wx.Frame):
             kb.OPEN_USER_GUIDE:     lambda: self._on_open_user_guide(None),
             kb.OPEN_HELP:           self._open_help_dialog,
         }
+
+    def _on_key_up(self, event: wx.KeyEvent) -> None:
+        """Release the monitor key (squelch defeat)."""
+        if self._monitor_active and event.GetKeyCode() in (ord("L"), wx.WXK_F4):
+            self._monitor_up()
+        event.Skip()
+
+    def _poll_monitor_key(self) -> None:
+        """Timer callback: release monitor if the key is no longer held."""
+        if not self._monitor_active:
+            return
+        f4_held = wx.GetKeyState(wx.WXK_F4)
+        l_held = wx.GetKeyState(ord("L"))
+        if not f4_held and not l_held:
+            self._monitor_up()
 
     def _dispatch_action(self, action: str) -> None:
         """Execute a keyboard action by name."""
@@ -1022,10 +1074,15 @@ class MainWindow(wx.Frame):
             ctcss = getattr(demod, "ctcss_tone", None)
             if ctcss is not None:
                 parts.append(_("CTCSS {tone:.1f} Hz").format(tone=ctcss))
-        squelch_open = db >= self._audio.squelch
-        parts.append(
-            _("Squelch open") if squelch_open else _("Squelch closed")
-        )
+        if not self._settings.squelch_enabled:
+            parts.append(_("Squelch off"))
+        else:
+            parts.append(
+                _("Squelch open") if self._audio._sq_open else _("Squelch closed")
+            )
+            parts.append(
+                _("Sensitivity {s}").format(s=self._settings.squelch_sensitivity)
+            )
         if self._audio.muted:
             parts.append(_("Muted"))
         if self._cursor.demod_offset != 0.0:
@@ -1117,7 +1174,7 @@ class MainWindow(wx.Frame):
         dlg = RFDialog(self, self._settings, valid_gains=valid_gains)
         if dlg.ShowModal() == wx.ID_OK:
             backend_changed = self._settings.rtl_tcp_active != old_active
-            if backend_changed and (self._radio.running or self._radio.paused):
+            if backend_changed and (self._radio.running):
                 self._stop_radio()
                 self._start_radio()
                 self._update_backend_status()
@@ -1306,7 +1363,7 @@ class MainWindow(wx.Frame):
         dlg.Destroy()
         # Check if the active server was removed or modified
         new_srv = self._settings.active_rtl_tcp_server()
-        if self._radio.running or self._radio.paused:
+        if self._radio.running:
             if old_srv != new_srv or self._settings.rtl_tcp_active != old_active:
                 self._stop_radio()
                 self._start_radio()
@@ -1377,7 +1434,7 @@ class MainWindow(wx.Frame):
         self._audio.stop()
         self._audio.device = settings.audio_device
         self._audio.blocksize = settings.audio_buffer_size
-        if self._radio.running or self._radio.paused:
+        if self._radio.running:
             self._audio.start()
         self._sync_sonification_device()
 
@@ -1405,7 +1462,7 @@ class MainWindow(wx.Frame):
         wx.CallAfter(self._stop_radio_on_error)
 
     def _stop_radio_on_error(self) -> None:
-        if self._radio.running or self._radio.paused:
+        if self._radio.running:
             self._stop_radio()
 
     # ==================================================================

--- a/ui/panels/channels_panel.py
+++ b/ui/panels/channels_panel.py
@@ -121,8 +121,8 @@ class ChannelsPanel(wx.Panel):
         self._bw_ctrl = wx.Choice(self, name="Channel bandwidth")
         grid.Add(self._bw_ctrl, 0)
 
-        grid.Add(wx.StaticText(self, label=_("Squelch (dBm, optional):")), 0, wx.ALIGN_CENTER_VERTICAL)
-        self._squelch_ctrl = wx.TextCtrl(self, name="Channel squelch")
+        grid.Add(wx.StaticText(self, label=_("Squelch sensitivity (0–10, optional):")), 0, wx.ALIGN_CENTER_VERTICAL)
+        self._squelch_ctrl = wx.TextCtrl(self, name="Channel squelch sensitivity")
         grid.Add(self._squelch_ctrl, 0)
 
         form_sizer.Add(grid, 0, wx.EXPAND | wx.ALL, 6)
@@ -280,7 +280,7 @@ class ChannelsPanel(wx.Panel):
         self._freq_ctrl.SetValue(fmt_freq(ch.frequency))
         self._mode_ctrl.SetStringSelection(ch.mode)
         self._refresh_bw_choices(ch.mode, ch.bandwidth)
-        self._squelch_ctrl.SetValue("" if ch.squelch is None else f"{ch.squelch:.0f}")
+        self._squelch_ctrl.SetValue("" if ch.squelch_sensitivity is None else str(ch.squelch_sensitivity))
         self._pending_overrides = {k: getattr(ch, k) for k in self._OVERRIDE_KEYS}
         self._update_ms_btn()
 
@@ -302,9 +302,9 @@ class ChannelsPanel(wx.Panel):
         bandwidth = self._form_bandwidth()
         sq_text = self._squelch_ctrl.GetValue().strip()
         try:
-            squelch = float(sq_text) if sq_text else None
+            squelch_sensitivity = int(sq_text) if sq_text else None
         except ValueError:
-            speech.output(_("Invalid squelch value."))
+            speech.output(_("Invalid squelch sensitivity."))
             return
         # Upsert by number.
         existing = next((c for c in cmap.channels if c.number == number), None)
@@ -316,7 +316,7 @@ class ChannelsPanel(wx.Panel):
             existing.frequency = freq_hz
             existing.mode = mode
             existing.bandwidth = bandwidth
-        existing.squelch = squelch
+        existing.squelch_sensitivity = squelch_sensitivity
         # Carry the modulation overrides edited via the Settings… button.
         for key, val in self._pending_overrides.items():
             setattr(existing, key, val)

--- a/ui/panels/scenes_panel.py
+++ b/ui/panels/scenes_panel.py
@@ -135,8 +135,8 @@ class ScenesPanel(wx.Panel):
         adv_sizer = wx.StaticBoxSizer(adv_box, wx.VERTICAL)
         adv_grid = wx.FlexGridSizer(cols=2, vgap=6, hgap=8)
         adv_grid.AddGrowableCol(1)
-        adv_grid.Add(wx.StaticText(self, label=_("Squelch (dBm):")), 0, wx.ALIGN_CENTER_VERTICAL)
-        self._squelch_ctrl = wx.TextCtrl(self, name="Squelch override")
+        adv_grid.Add(wx.StaticText(self, label=_("Squelch sensitivity (0–10):")), 0, wx.ALIGN_CENTER_VERTICAL)
+        self._squelch_ctrl = wx.TextCtrl(self, name="Squelch sensitivity override")
         adv_grid.Add(self._squelch_ctrl, 1, wx.EXPAND)
         adv_sizer.Add(adv_grid, 0, wx.EXPAND | wx.ALL, 6)
         form_sizer.Add(adv_sizer, 0, wx.EXPAND | wx.ALL, 4)
@@ -246,7 +246,7 @@ class ScenesPanel(wx.Panel):
             _STEP_VALUES.index(s.step) if s.step in _STEP_VALUES else 0
         )
         self._default_ctrl.SetValue("" if s.default_freq is None else fmt_freq(s.default_freq))
-        self._squelch_ctrl.SetValue("" if s.squelch is None else f"{s.squelch:.0f}")
+        self._squelch_ctrl.SetValue("" if s.squelch_sensitivity is None else str(s.squelch_sensitivity))
         self._pending_overrides = {k: getattr(s, k) for k in self._OVERRIDE_KEYS}
         self._update_ms_btn()
 
@@ -262,7 +262,7 @@ class ScenesPanel(wx.Panel):
         except ValueError:
             speech.output(_("Invalid frequency."))
             return None
-        squelch = self._squelch_ctrl.GetValue().strip()
+        sq_text = self._squelch_ctrl.GetValue().strip()
         group = self._group_ctrl.GetValue().strip()
         try:
             scene = Scene(
@@ -273,7 +273,7 @@ class ScenesPanel(wx.Panel):
                 bandwidth=self._form_bandwidth(),
                 step=_STEP_VALUES[self._step_ctrl.GetSelection()],
                 default_freq=default_freq,
-                squelch=float(squelch) if squelch else None,
+                squelch_sensitivity=int(sq_text) if sq_text else None,
                 group=group,
             )
         except ValueError:

--- a/ui/radio_controller.py
+++ b/ui/radio_controller.py
@@ -34,7 +34,6 @@ class RadioController:
         self._sdr = SDRDevice(chunk_size=settings.sdr_buffer_size, settings=settings)
         self._pipeline: Optional[DSPPipeline] = None
         self._running = False
-        self._paused = False
 
     # ------------------------------------------------------------------
     # Properties
@@ -43,10 +42,6 @@ class RadioController:
     @property
     def running(self) -> bool:
         return self._running
-
-    @property
-    def paused(self) -> bool:
-        return self._paused
 
     @property
     def pipeline(self) -> Optional[DSPPipeline]:
@@ -90,6 +85,12 @@ class RadioController:
         mode = self._settings.mode
         wfm_kw = self.wfm_kwargs() if mode == "WFM" else {}
         nfm_kw = self.nfm_kwargs() if mode == "NFM" else {}
+        # Wire auto squelch callbacks into pipeline callbacks
+        callbacks.noise_db_setter = (
+            lambda db: setattr(self._audio, "noise_db", db))
+        callbacks.auto_squelch_threshold_setter = (
+            lambda db: setattr(self._audio, "auto_squelch_threshold", db))
+
         self._pipeline = DSPPipeline(
             sample_rate=self._settings.sample_rate,
             chunk_size=self._sdr.chunk_size,
@@ -104,6 +105,11 @@ class RadioController:
             nfm_kwargs=nfm_kw,
             callbacks=callbacks,
         )
+
+        # Sync squelch state
+        self._audio.squelch_enabled = self._settings.squelch_enabled
+        self._audio.current_mode = mode
+        self._pipeline.set_squelch_sensitivity(self._settings.squelch_sensitivity)
 
         # Configure SDR hardware. Direct sampling first: it changes the
         # signal path, so the frequency below must be set in the right mode.
@@ -127,38 +133,16 @@ class RadioController:
         self._audio.start()
 
         self._running = True
-        self._paused = False
         return True
 
     def stop(self) -> None:
         """Stop capture, close SDR, stop audio, destroy pipeline."""
         self._running = False
-        self._paused = False
         self._sdr.stop()
         self._sdr.on_samples = None
         self._sdr.close()
         self._audio.stop()
         self._pipeline = None
-
-    def pause(self) -> bool:
-        """Pause capture and audio.
-
-        Returns True if paused, False if radio is already stopped.
-        """
-        if not self._running and not self._paused:
-            return False
-        self._sdr.pause()
-        self._audio.pause()
-        self._running = False
-        self._paused = True
-        return True
-
-    def resume(self) -> None:
-        """Resume capture and audio from paused state."""
-        self._sdr.start()
-        self._audio.resume()
-        self._running = True
-        self._paused = False
 
     # ------------------------------------------------------------------
     # Hardware / pipeline control
@@ -177,6 +161,11 @@ class RadioController:
         self._sdr.set_frequency(self._hw_freq(freq_hz))
         if self._pipeline is not None:
             self._pipeline.notify_retune()
+        # Force squelch gate closed so it must re-open based on the new
+        # frequency's metrics.  Prevents stale open state during scanning.
+        if hasattr(self._audio, "_sq_open"):
+            self._audio._sq_open = False
+            self._audio._sq_hang_remaining = 0
 
     def set_mode(
         self,
@@ -187,6 +176,7 @@ class RadioController:
         """Change demod mode on pipeline and set tuner BW to auto."""
         if self._pipeline is not None:
             self._pipeline.set_mode(mode, wfm_kwargs or {}, nfm_kwargs or {})
+        self._audio.current_mode = mode
         if self._running:
             self._sdr.set_tuner_bandwidth(0)
 


### PR DESCRIPTION
## Summary

- **Hardware-style carrier squelch** replacing the unreliable manual dBFS threshold:
  - FM (WFM/NFM): above-audio noise measurement on discriminator output, noise band adapts to deviation
  - AM/DSB: carrier-to-noise ratio on channel-filtered IQ envelope (airband-tested)
  - SSB/CW: adaptive RSSI noise floor tracking with IIR follower
- **Simplified UI** — sensitivity slider (0–10) + squelch off toggle + monitor key (F4 hold), no more manual dBm slider
- **Scanner** uses live auto squelch gate instead of fixed threshold; gate resets on retune
- **Remove pause/resume** (Space key) — mute is sufficient
- **Fix CB CEPT channels** — ship both FM (±2 kHz NFM) and AM maps for Portugal/CEPT

## Test plan

- [ ] FM Radio: squelch opens on station, closes on empty freq
- [ ] Airband AM: squelch works with sensitivity control
- [ ] PMR446/CB NFM: squelch closes on quiet channels
- [ ] Sensitivity slider (Shift+F11/F12) adjusts threshold responsiveness
- [ ] F4 hold = monitor (momentary squelch defeat)
- [ ] Ctrl+F4 = toggle squelch on/off
- [ ] Scanner detects signals without noise blasts between channels
- [ ] All 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)